### PR TITLE
Dodane real-time notifikacije za nove alarme - closes #13

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -310,6 +310,42 @@ app.patch('/api/alarms/:id/read', authenticateRequest, (req: AuthenticatedReques
   res.json({ alarm });
 });
 
+/* ===== Simulacija novih alarma (za testiranje real-time notifikacija) ===== */
+let nextAlarmId = 11; // prvi novi alarm dobiva id 11 (postojece ih je 10)
+
+const simulationPool: { type: AlarmType; camera: string; message: string }[] = [
+  { type: 'motion',  camera: 'Ulazna vrata',      message: 'Pokret detektiran' },
+  { type: 'sound',   camera: 'Dnevni boravak',    message: 'Detektiran glasan zvuk' },
+  { type: 'offline', camera: 'Garaža',            message: 'Kamera izgubila vezu' },
+  { type: 'door',    camera: 'Stražnje dvorište', message: 'Vrata otvorena' },
+  { type: 'temp',    camera: 'Spremište',         message: 'Temperatura previsoka' },
+  { type: 'motion',  camera: 'Hodnik - 1. kat',   message: 'Pokret detektiran' },
+];
+
+app.post('/api/alarms/simulate', authenticateRequest, (req: AuthenticatedRequest, res) => {
+  const body = req.body ?? {};
+  const pick = simulationPool[Math.floor(Math.random() * simulationPool.length)];
+
+  const type: AlarmType = body.type && ['motion', 'sound', 'offline', 'door', 'temp'].includes(body.type)
+    ? body.type
+    : pick.type;
+
+  const camera = typeof body.camera === 'string' && body.camera.trim() ? body.camera.trim() : pick.camera;
+  const message = typeof body.message === 'string' && body.message.trim() ? body.message.trim() : pick.message;
+
+  const alarm: MockAlarm = {
+    id: String(nextAlarmId++),
+    type,
+    camera,
+    message,
+    time: new Date().toISOString(),
+    isRead: false,
+  };
+
+  mockAlarms.push(alarm);
+  res.status(201).json({ alarm });
+});
+
 /* ===== Mock kamere ===== */
 type MockCamera = {
   id: string;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,7 +9,7 @@ import PlaceholderPage from './pages/PlaceholderPage';
 import AccountPage from './pages/AccountPage';
 import ProtectedRoute from './components/ProtectedRoute';
 import PublicRoute from './components/PublicRoute';
-import AppLayout from './components/AppLayout';
+import ProtectedShell from './components/ProtectedShell';
 
 function App() {
   return (
@@ -20,9 +20,9 @@ function App() {
         <Route path="/register" element={<RegisterPage />} />
       </Route>
 
-      {/* Zaštićene rute — zahtijevaju prijavu, koriste zajednički layout */}
+      {/* Zaštićene rute — zahtijevaju prijavu, koriste zajednički layout i notifikacije */}
       <Route element={<ProtectedRoute />}>
-        <Route element={<AppLayout />}>
+        <Route element={<ProtectedShell />}>
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/kamere" element={<CamerasPage />} />
           <Route path="/kamere/:id" element={<CameraDetailPage />} />

--- a/web/src/components/AppLayout.css
+++ b/web/src/components/AppLayout.css
@@ -99,6 +99,37 @@
   flex-shrink: 0;
 }
 
+.nav-label {
+  flex: 1;
+}
+
+/* ===== Badge u sidebaru (broj nepročitanih alarma) ===== */
+.nav-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  background: #dc2626;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+  font-family: 'Outfit', sans-serif;
+  animation: badgePulse 2s ease-in-out infinite;
+}
+
+@keyframes badgePulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0.5); }
+  50%      { box-shadow: 0 0 0 6px rgba(220, 38, 38, 0); }
+}
+
+.nav-link-active .nav-badge {
+  background: #dc2626;
+}
+
 /* ===== Sidebar footer ===== */
 .sidebar-footer {
   padding: 1rem 1.3rem;
@@ -140,6 +171,53 @@
 .header-greeting {
   font-size: 0.88rem;
   color: var(--text-secondary);
+}
+
+/* ===== Zvonce u header-u ===== */
+.header-bell-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.header-bell-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.header-bell-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.header-bell-badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: #dc2626;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  line-height: 1;
+  font-family: 'Outfit', sans-serif;
+  border: 2px solid var(--bg-surface);
+  animation: badgePulse 2s ease-in-out infinite;
 }
 
 .header-greeting strong {

--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import { getAuthToken, clearAuthToken } from '../lib/auth';
+import { useNotifications } from '../contexts/NotificationsContext';
 import './AppLayout.css';
 
 /** Dekodira ime korisnika iz JWT payload-a. */
@@ -29,6 +30,7 @@ function AppLayout() {
   const navigate = useNavigate();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const userName = getUserName();
+  const { unreadCount } = useNotifications();
 
   const handleLogout = () => {
     clearAuthToken();
@@ -59,19 +61,27 @@ function AppLayout() {
         </div>
 
         <nav className="sidebar-nav">
-          {navItems.map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              className={({ isActive }) => `nav-link ${isActive ? 'nav-link-active' : ''}`}
-              onClick={closeSidebar}
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="nav-icon">
-                <path d={item.icon} />
-              </svg>
-              <span>{item.label}</span>
-            </NavLink>
-          ))}
+          {navItems.map((item) => {
+            const showBadge = item.to === '/alarmi' && unreadCount > 0;
+            return (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) => `nav-link ${isActive ? 'nav-link-active' : ''}`}
+                onClick={closeSidebar}
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="nav-icon">
+                  <path d={item.icon} />
+                </svg>
+                <span className="nav-label">{item.label}</span>
+                {showBadge && (
+                  <span className="nav-badge" aria-label={`${unreadCount} nepročitanih alarma`}>
+                    {unreadCount > 99 ? '99+' : unreadCount}
+                  </span>
+                )}
+              </NavLink>
+            );
+          })}
         </nav>
 
         <div className="sidebar-footer">
@@ -105,6 +115,24 @@ function AppLayout() {
           </button>
 
           <div className="header-spacer" />
+
+          {/* Zvonce s brojem nepročitanih — vidljivo na mobitelu kad je sidebar skriven */}
+          <button
+            type="button"
+            className="header-bell-btn"
+            onClick={() => navigate('/alarmi')}
+            aria-label={unreadCount > 0 ? `${unreadCount} nepročitanih alarma` : 'Otvori alarme'}
+            title="Alarmi"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+            </svg>
+            {unreadCount > 0 && (
+              <span className="header-bell-badge">
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </span>
+            )}
+          </button>
 
           {userName && (
             <span className="header-greeting">

--- a/web/src/components/ProtectedShell.tsx
+++ b/web/src/components/ProtectedShell.tsx
@@ -1,0 +1,19 @@
+import { NotificationsProvider } from '../contexts/NotificationsContext';
+import AppLayout from './AppLayout';
+import ToastContainer from './ToastContainer';
+
+/**
+ * Omotava AppLayout s providerom za real-time notifikacije.
+ * Polling i toast notifikacije rade samo za prijavljene korisnike
+ * jer se ova komponenta renderira samo unutar ProtectedRoute.
+ */
+function ProtectedShell() {
+  return (
+    <NotificationsProvider>
+      <AppLayout />
+      <ToastContainer />
+    </NotificationsProvider>
+  );
+}
+
+export default ProtectedShell;

--- a/web/src/components/ToastContainer.css
+++ b/web/src/components/ToastContainer.css
@@ -1,0 +1,181 @@
+/*
+ * ToastContainer — popup notifikacije za nove alarme.
+ * Pozicija: fixed bottom-right, stack prema gore, auto-dismiss 6s.
+ */
+
+.toast-container {
+  position: fixed;
+  bottom: 1.25rem;
+  right: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  z-index: 300;
+  max-width: 380px;
+  width: calc(100% - 2.5rem);
+  pointer-events: none;
+}
+
+.toast {
+  position: relative;
+  display: flex;
+  gap: 0.85rem;
+  padding: 1rem 1rem 1rem 1.1rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-left-width: 3px;
+  border-radius: var(--radius);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  pointer-events: auto;
+  animation: toastSlideIn 0.3s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.toast:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-hover);
+}
+
+@keyframes toastSlideIn {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* ===== Lijevi rub po tipu ===== */
+.toast-type-motion     { border-left-color: #fb923c; }
+.toast-type-sound      { border-left-color: #60a5fa; }
+.toast-type-offline    { border-left-color: #6b7280; }
+.toast-type-door       { border-left-color: #a855f7; }
+.toast-type-temp       { border-left-color: #ef4444; }
+
+/* ===== Badge ===== */
+.toast-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.toast-badge-motion  { background: rgba(251, 146, 60, 0.14); color: #fb923c; }
+.toast-badge-sound   { background: rgba(96, 165, 250, 0.14); color: #60a5fa; }
+.toast-badge-offline { background: rgba(107, 114, 128, 0.18); color: #9ca3af; }
+.toast-badge-door    { background: rgba(168, 85, 247, 0.14); color: #a855f7; }
+.toast-badge-temp    { background: rgba(239, 68, 68, 0.14); color: #ef4444; }
+
+/* ===== Body ===== */
+.toast-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.toast-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.2rem;
+}
+
+.toast-type-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.toast-camera {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.toast-message {
+  margin: 0 0 0.6rem 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.toast-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.toast-action-btn {
+  padding: 0.35rem 0.6rem;
+  border-radius: 5px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.toast-action-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.toast-action-read:hover {
+  border-color: #34d399;
+  color: #34d399;
+}
+
+/* ===== Close ===== */
+.toast-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: all 0.15s ease;
+}
+
+.toast-close svg {
+  width: 14px;
+  height: 14px;
+}
+
+.toast-close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 540px) {
+  .toast-container {
+    bottom: 1rem;
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+    max-width: none;
+  }
+}

--- a/web/src/components/ToastContainer.tsx
+++ b/web/src/components/ToastContainer.tsx
@@ -1,0 +1,102 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useNotifications } from '../contexts/NotificationsContext';
+import type { Toast as ToastType, AlarmType } from '../contexts/NotificationsContext';
+import './ToastContainer.css';
+
+const AUTO_DISMISS_MS = 6000;
+
+const typeLabels: Record<AlarmType, string> = {
+  motion:  'Pokret',
+  sound:   'Zvuk',
+  offline: 'Offline',
+  door:    'Vrata',
+  temp:    'Temperatura',
+};
+
+const typeShort: Record<AlarmType, string> = {
+  motion:  'MOT',
+  sound:   'SND',
+  offline: 'OFF',
+  door:    'DOR',
+  temp:    'TMP',
+};
+
+function Toast({ toast }: { toast: ToastType }) {
+  const { dismissToast, markAsRead } = useNotifications();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const timer = setTimeout(() => dismissToast(toast.id), AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [toast.id, dismissToast]);
+
+  const handleClick = () => {
+    dismissToast(toast.id);
+    navigate('/alarmi');
+  };
+
+  const handleMarkRead = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    void markAsRead(toast.alarm.id);
+    dismissToast(toast.id);
+  };
+
+  const handleDismiss = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    dismissToast(toast.id);
+  };
+
+  return (
+    <div
+      className={`toast toast-type-${toast.alarm.type}`}
+      onClick={handleClick}
+      role="alert"
+    >
+      <span className={`toast-badge toast-badge-${toast.alarm.type}`}>
+        {typeShort[toast.alarm.type]}
+      </span>
+      <div className="toast-body">
+        <div className="toast-title">
+          <span className="toast-type-label">{typeLabels[toast.alarm.type]}</span>
+          <span className="toast-camera">{toast.alarm.camera}</span>
+        </div>
+        <p className="toast-message">{toast.alarm.message}</p>
+        <div className="toast-actions">
+          <button type="button" className="toast-action-btn toast-action-read" onClick={handleMarkRead}>
+            Označi pročitanim
+          </button>
+          <button type="button" className="toast-action-btn" onClick={handleClick}>
+            Otvori alarme
+          </button>
+        </div>
+      </div>
+      <button
+        type="button"
+        className="toast-close"
+        onClick={handleDismiss}
+        aria-label="Zatvori notifikaciju"
+      >
+        <svg viewBox="0 0 20 20" fill="currentColor">
+          <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+function ToastContainer() {
+  const { toasts } = useNotifications();
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="toast-container" aria-live="polite">
+      {toasts.map((toast) => (
+        <Toast key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+}
+
+export default ToastContainer;

--- a/web/src/contexts/NotificationsContext.tsx
+++ b/web/src/contexts/NotificationsContext.tsx
@@ -1,0 +1,185 @@
+import { createContext, useContext, useEffect, useState, useRef, useCallback } from 'react';
+import type { ReactNode } from 'react';
+import { apiFetch } from '../lib/api';
+import { getAuthToken } from '../lib/auth';
+
+/* ===== Tipovi ===== */
+export type AlarmType = 'motion' | 'sound' | 'offline' | 'door' | 'temp';
+
+export type Alarm = {
+  id: string;
+  type: AlarmType;
+  camera: string;
+  message: string;
+  time: string;
+  isRead: boolean;
+};
+
+export type Toast = {
+  id: string;
+  alarm: Alarm;
+};
+
+type NotificationsContextValue = {
+  alarms: Alarm[];
+  unreadCount: number;
+  isLoading: boolean;
+  toasts: Toast[];
+  dismissToast: (toastId: string) => void;
+  markAsRead: (alarmId: string) => Promise<void>;
+  markAllAsRead: () => Promise<void>;
+  refresh: () => Promise<void>;
+};
+
+const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+
+/* ===== Konstante ===== */
+const POLL_INTERVAL_MS = 10_000; // 10 sekundi
+const CRITICAL_TYPES: AlarmType[] = ['offline', 'temp'];
+
+/* ===== Zvučni signal (Web Audio API) ===== */
+function playBeep(isCritical: boolean) {
+  try {
+    const AudioCtx = window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    if (!AudioCtx) return;
+    const ctx = new AudioCtx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = 'sine';
+    osc.frequency.value = isCritical ? 880 : 600;
+    gain.gain.setValueAtTime(0.15, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.35);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.35);
+
+    // Kod kritičnih — dvostruki beep
+    if (isCritical) {
+      const osc2 = ctx.createOscillator();
+      const gain2 = ctx.createGain();
+      osc2.connect(gain2);
+      gain2.connect(ctx.destination);
+      osc2.type = 'sine';
+      osc2.frequency.value = 880;
+      gain2.gain.setValueAtTime(0.15, ctx.currentTime + 0.4);
+      gain2.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.75);
+      osc2.start(ctx.currentTime + 0.4);
+      osc2.stop(ctx.currentTime + 0.75);
+    }
+  } catch {
+    /* ignoriraj — neki browseri traže user gesture */
+  }
+}
+
+/* ===== Provider ===== */
+export function NotificationsProvider({ children }: { children: ReactNode }) {
+  const [alarms, setAlarms] = useState<Alarm[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  // ID-jevi alarma koje smo već vidjeli (pratimo kad stigne nova)
+  const seenIdsRef = useRef<Set<string>>(new Set());
+  // Preskoci toast/zvuk pri prvom učitavanju (inače bi ih bilo 10 odjednom)
+  const isFirstLoadRef = useRef(true);
+
+  const fetchAlarms = useCallback(async () => {
+    if (!getAuthToken()) return;
+
+    try {
+      const response = await apiFetch('/api/alarms', { includeAuth: true });
+      if (!response.ok) return;
+
+      const data = await response.json();
+      const fetched: Alarm[] = data.alarms ?? [];
+
+      if (!isFirstLoadRef.current) {
+        // Detektiraj nove nepročitane koji još nisu bili viđeni
+        const newOnes = fetched.filter((a) => !a.isRead && !seenIdsRef.current.has(a.id));
+
+        if (newOnes.length > 0) {
+          const newToasts = newOnes.map((alarm) => ({
+            id: `toast-${alarm.id}-${Date.now()}`,
+            alarm,
+          }));
+          setToasts((prev) => [...prev, ...newToasts]);
+
+          // Zvuk — ako je bilo koji kritičan, sviraj kritični pattern
+          const hasCritical = newOnes.some((a) => CRITICAL_TYPES.includes(a.type));
+          playBeep(hasCritical);
+        }
+      }
+
+      // Ažuriraj praćenje seen ID-jeva
+      fetched.forEach((a) => seenIdsRef.current.add(a.id));
+
+      setAlarms(fetched);
+      isFirstLoadRef.current = false;
+    } catch {
+      /* ignoriraj greške pollinga */
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  /* Initial load + polling */
+  useEffect(() => {
+    void fetchAlarms();
+    const interval = setInterval(() => {
+      void fetchAlarms();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchAlarms]);
+
+  const dismissToast = useCallback((toastId: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== toastId));
+  }, []);
+
+  const markAsRead = useCallback(async (alarmId: string) => {
+    const response = await apiFetch(`/api/alarms/${alarmId}/read`, {
+      method: 'PATCH',
+      includeAuth: true,
+    });
+    if (response.ok) {
+      setAlarms((prev) => prev.map((a) => (a.id === alarmId ? { ...a, isRead: true } : a)));
+    }
+  }, []);
+
+  const markAllAsRead = useCallback(async () => {
+    const response = await apiFetch('/api/alarms/read-all', {
+      method: 'PATCH',
+      includeAuth: true,
+    });
+    if (response.ok) {
+      setAlarms((prev) => prev.map((a) => ({ ...a, isRead: true })));
+    }
+  }, []);
+
+  const unreadCount = alarms.filter((a) => !a.isRead).length;
+
+  return (
+    <NotificationsContext.Provider
+      value={{
+        alarms,
+        unreadCount,
+        isLoading,
+        toasts,
+        dismissToast,
+        markAsRead,
+        markAllAsRead,
+        refresh: fetchAlarms,
+      }}
+    >
+      {children}
+    </NotificationsContext.Provider>
+  );
+}
+
+/* ===== Hook ===== */
+export function useNotifications() {
+  const ctx = useContext(NotificationsContext);
+  if (!ctx) {
+    throw new Error('useNotifications must be used within NotificationsProvider');
+  }
+  return ctx;
+}

--- a/web/src/pages/AlarmsPage.css
+++ b/web/src/pages/AlarmsPage.css
@@ -70,6 +70,39 @@
   color: #fff;
 }
 
+/* ===== Simuliraj gumb (za testiranje real-time) ===== */
+.alarms-simulate-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--border-hover);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.alarms-simulate-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.alarms-simulate-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+  border-style: solid;
+}
+
+.alarms-simulate-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ===== Filteri ===== */
 .alarms-filters {
   display: flex;

--- a/web/src/pages/AlarmsPage.tsx
+++ b/web/src/pages/AlarmsPage.tsx
@@ -1,21 +1,10 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import './AlarmsPage.css';
 import { apiFetch } from '../lib/api';
-import { clearAuthToken } from '../lib/auth';
+import { useNotifications } from '../contexts/NotificationsContext';
+import type { AlarmType } from '../contexts/NotificationsContext';
 
 /* ===== Tipovi ===== */
-type AlarmType = 'motion' | 'sound' | 'offline' | 'door' | 'temp';
-
-type Alarm = {
-  id: string;
-  type: AlarmType;
-  camera: string;
-  message: string;
-  time: string;
-  isRead: boolean;
-};
-
 type FilterType = 'all' | AlarmType;
 type FilterStatus = 'all' | 'unread' | 'read';
 
@@ -41,58 +30,24 @@ const formatTime = (iso: string) => {
 
 /* ===== Komponenta ===== */
 function AlarmsPage() {
-  const navigate = useNavigate();
-  const [alarms, setAlarms] = useState<Alarm[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState('');
+  const { alarms, isLoading, markAsRead, markAllAsRead, refresh } = useNotifications();
   const [filterType, setFilterType] = useState<FilterType>('all');
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
+  const [isSimulating, setIsSimulating] = useState(false);
 
-  const loadAlarms = async () => {
-    setIsLoading(true);
-    setError('');
+  /* Simuliraj novi alarm (za testiranje real-time notifikacija) */
+  const handleSimulate = async () => {
+    setIsSimulating(true);
     try {
-      const response = await apiFetch('/api/alarms', { includeAuth: true });
-      const data = await response.json();
-
-      if (response.status === 401) {
-        clearAuthToken();
-        navigate('/login', { replace: true });
-        return;
-      }
-
-      if (!response.ok) {
-        setError(data.message || 'Neuspješno dohvaćanje alarma.');
-        return;
-      }
-
-      setAlarms(data.alarms ?? []);
-    } catch {
-      setError('Greška pri dohvaćanju alarma.');
+      await apiFetch('/api/alarms/simulate', {
+        method: 'POST',
+        includeAuth: true,
+        body: JSON.stringify({}),
+      });
+      // Brzi refresh da korisnik odmah vidi novi alarm, bez čekanja na sljedeći poll tick
+      await refresh();
     } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => { void loadAlarms(); }, [navigate]);
-
-  const markRead = async (id: string) => {
-    const response = await apiFetch(`/api/alarms/${id}/read`, {
-      method: 'PATCH',
-      includeAuth: true,
-    });
-    if (response.ok) {
-      setAlarms((prev) => prev.map((a) => a.id === id ? { ...a, isRead: true } : a));
-    }
-  };
-
-  const markAllRead = async () => {
-    const response = await apiFetch('/api/alarms/read-all', {
-      method: 'PATCH',
-      includeAuth: true,
-    });
-    if (response.ok) {
-      setAlarms((prev) => prev.map((a) => ({ ...a, isRead: true })));
+      setIsSimulating(false);
     }
   };
 
@@ -121,8 +76,20 @@ function AlarmsPage() {
           <span className="alarms-stat alarms-stat-unread">
             Nepročitano: <strong>{unreadCount}</strong>
           </span>
+          <button
+            type="button"
+            className="alarms-simulate-btn"
+            onClick={handleSimulate}
+            disabled={isSimulating}
+            title="Simulira novi alarm iz backenda (za testiranje)"
+          >
+            <svg viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clipRule="evenodd" />
+            </svg>
+            {isSimulating ? 'Simuliram...' : 'Simuliraj alarm'}
+          </button>
           {unreadCount > 0 && (
-            <button type="button" className="alarms-mark-all-btn" onClick={markAllRead}>
+            <button type="button" className="alarms-mark-all-btn" onClick={() => void markAllAsRead()}>
               Označi sve kao pročitano
             </button>
           )}
@@ -159,13 +126,6 @@ function AlarmsPage() {
         </div>
       </div>
 
-      {/* Error */}
-      {error && (
-        <div className="alarms-error">
-          <p>{error}</p>
-        </div>
-      )}
-
       {/* Loading */}
       {isLoading && (
         <div className="alarms-loading">
@@ -175,7 +135,7 @@ function AlarmsPage() {
       )}
 
       {/* Tablica */}
-      {!isLoading && !error && (
+      {!isLoading && (
         <>
           {filtered.length === 0 ? (
             <div className="alarms-empty">
@@ -218,7 +178,7 @@ function AlarmsPage() {
                           <button
                             type="button"
                             className="alarm-read-btn"
-                            onClick={() => void markRead(alarm.id)}
+                            onClick={() => void markAsRead(alarm.id)}
                           >
                             Označi pročitanim
                           </button>


### PR DESCRIPTION
NotificationsContext: polling svakih 10s, detekcija novih alarma,
  unread count, toast queue, Web Audio beep za kriticne alarme
- ToastContainer: popup dolje desno, auto-dismiss 6s, obojen po tipu
- Badge s brojem neprocitanih u sidebaru (Alarmi) i header-u (zvonce)
- ProtectedShell: omota AppLayout s NotificationsProvider-om
- AlarmsPage: koristi context, dodan gumb "Simuliraj alarm" za testiranje
- Backend: POST /api/alarms/simulate endpoint za simulaciju novih alarma
- Kriticni tipovi (offline, temp) sviraju dvostruki beep