### PR TITLE
Mobile senzori: integracija s API-jem, CRUD, detalji

### DIFF
--- a/mobile/src/components/ApiKeyModal.tsx
+++ b/mobile/src/components/ApiKeyModal.tsx
@@ -1,0 +1,164 @@
+import { Modal, View, Text, Pressable, StyleSheet, Share } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+import { colors, radius } from '../theme/colors';
+import { typography } from '../theme/typography';
+
+type Props = {
+  visible: boolean;
+  apiKey: string | null;
+  onClose: () => void;
+};
+
+export function ApiKeyModal({ visible, apiKey, onClose }: Props) {
+  const handleShare = async () => {
+    if (!apiKey) return;
+    try {
+      await Share.share({ message: apiKey });
+    } catch {
+      // ignoriraj
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <View style={styles.backdrop}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        <View style={styles.center} pointerEvents="box-none">
+          <View style={styles.card}>
+            <View style={styles.header}>
+              <Text style={styles.title}>Senzor uspješno dodan</Text>
+              <Pressable onPress={onClose} hitSlop={8} style={styles.closeBtn}>
+                <Svg viewBox="0 0 20 20" width={20} height={20} fill={colors.textSecondary}>
+                  <Path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+                </Svg>
+              </Pressable>
+            </View>
+
+            <View style={styles.body}>
+              <Text style={styles.notice}>
+                Spremite ovaj API ključ — prikazuje se samo jednom. Uređaj ga koristi za slanje događaja preko {`\n`}
+                <Text style={styles.mono}>Authorization: Bearer API_KEY</Text>.
+              </Text>
+
+              <View style={styles.keyBox}>
+                <Text style={styles.keyText} selectable>
+                  {apiKey ?? ''}
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.actions}>
+              <Pressable
+                onPress={handleShare}
+                style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.btnPressed]}
+              >
+                <Text style={styles.btnPrimaryText}>Podijeli / Kopiraj</Text>
+              </Pressable>
+              <Pressable
+                onPress={onClose}
+                style={({ pressed }) => [styles.btn, styles.btnCancel, pressed && styles.btnPressed]}
+              >
+                <Text style={styles.btnCancelText}>Zatvori</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.65)' },
+  center: { flex: 1, justifyContent: 'center', paddingHorizontal: 18 },
+  card: {
+    backgroundColor: colors.bgSurface,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radius.card,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderSubtle,
+  },
+  title: {
+    ...typography.formHeader,
+    color: colors.textPrimary,
+    fontSize: 16,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  body: {
+    padding: 18,
+    gap: 12,
+  },
+  notice: {
+    ...typography.formSubheader,
+    color: colors.textSecondary,
+    lineHeight: 20,
+  },
+  mono: {
+    fontFamily: 'monospace',
+    color: colors.accent,
+    fontSize: 12,
+  },
+  keyBox: {
+    backgroundColor: colors.bgInput,
+    borderWidth: 1,
+    borderColor: colors.accentGlow,
+    borderRadius: radius.input,
+    padding: 12,
+  },
+  keyText: {
+    fontFamily: 'monospace',
+    color: colors.accent,
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 10,
+    padding: 18,
+    borderTopWidth: 1,
+    borderTopColor: colors.borderSubtle,
+  },
+  btn: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: radius.button,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnPrimary: { backgroundColor: colors.accent },
+  btnCancel: {
+    backgroundColor: colors.bgInput,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+  },
+  btnPressed: { opacity: 0.85 },
+  btnPrimaryText: {
+    ...typography.button,
+    color: colors.bgDeep,
+  },
+  btnCancelText: {
+    ...typography.button,
+    color: colors.textPrimary,
+    fontSize: 14,
+  },
+});

--- a/mobile/src/components/SensorFormModal.tsx
+++ b/mobile/src/components/SensorFormModal.tsx
@@ -1,0 +1,389 @@
+import { useEffect, useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+import { colors, radius } from '../theme/colors';
+import { typography } from '../theme/typography';
+import type { SensorType } from '../data/mockData';
+
+export type SensorFormData = {
+  name: string;
+  type: SensorType;
+  location: string;
+  status?: 'active' | 'inactive';
+};
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit: (data: SensorFormData) => Promise<void>;
+  initialData?: SensorFormData | null;
+  isEdit?: boolean;
+};
+
+const typeOptions: { value: SensorType; label: string }[] = [
+  { value: 'door', label: 'Vrata' },
+  { value: 'window', label: 'Prozor' },
+  { value: 'smoke', label: 'Dim' },
+  { value: 'temperature', label: 'Temperatura' },
+  { value: 'motion', label: 'Pokret' },
+];
+
+const statusOptions: { value: 'active' | 'inactive'; label: string }[] = [
+  { value: 'active', label: 'Aktivan' },
+  { value: 'inactive', label: 'Neaktivan' },
+];
+
+export function SensorFormModal({
+  visible,
+  onClose,
+  onSubmit,
+  initialData,
+  isEdit,
+}: Props) {
+  const [name, setName] = useState('');
+  const [type, setType] = useState<SensorType>('door');
+  const [location, setLocation] = useState('');
+  const [status, setStatus] = useState<'active' | 'inactive'>('active');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!visible) return;
+    if (initialData) {
+      setName(initialData.name);
+      setType(initialData.type);
+      setLocation(initialData.location);
+      setStatus(initialData.status ?? 'active');
+    } else {
+      setName('');
+      setType('door');
+      setLocation('');
+      setStatus('active');
+    }
+    setError('');
+  }, [visible, initialData]);
+
+  const handleSubmit = async () => {
+    setError('');
+    if (!name.trim()) {
+      setError('Naziv senzora je obavezan.');
+      return;
+    }
+    if (!location.trim()) {
+      setError('Lokacija je obavezna.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        name: name.trim(),
+        type,
+        location: location.trim(),
+        ...(isEdit ? { status } : {}),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Došlo je do greške.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <View style={styles.backdrop}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.center}
+          pointerEvents="box-none"
+        >
+          <View style={styles.card}>
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.title}>
+                {isEdit ? 'Uredi senzor' : 'Dodaj novi senzor'}
+              </Text>
+              <Pressable onPress={onClose} hitSlop={8} style={styles.closeBtn}>
+                <Svg viewBox="0 0 20 20" width={20} height={20} fill={colors.textSecondary}>
+                  <Path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+                </Svg>
+              </Pressable>
+            </View>
+
+            <ScrollView
+              contentContainerStyle={styles.form}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+            >
+              {!!error && (
+                <View style={styles.errorBox}>
+                  <Text style={styles.errorText}>{error}</Text>
+                </View>
+              )}
+
+              <View style={styles.field}>
+                <Text style={styles.label}>Naziv senzora *</Text>
+                <TextInput
+                  style={styles.input}
+                  value={name}
+                  onChangeText={setName}
+                  placeholder="npr. Senzor ulaznih vrata"
+                  placeholderTextColor={colors.textMuted}
+                  editable={!isSubmitting}
+                />
+              </View>
+
+              <View style={styles.field}>
+                <Text style={styles.label}>Tip *</Text>
+                <View style={styles.chipRow}>
+                  {typeOptions.map((opt) => {
+                    const active = type === opt.value;
+                    return (
+                      <Pressable
+                        key={opt.value}
+                        onPress={() => setType(opt.value)}
+                        disabled={isSubmitting}
+                        style={({ pressed }) => [
+                          styles.chip,
+                          active && styles.chipActive,
+                          pressed && !active && styles.chipPressed,
+                        ]}
+                      >
+                        <Text style={[styles.chipText, active && styles.chipTextActive]}>
+                          {opt.label}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+
+              <View style={styles.field}>
+                <Text style={styles.label}>Lokacija *</Text>
+                <TextInput
+                  style={styles.input}
+                  value={location}
+                  onChangeText={setLocation}
+                  placeholder="npr. Ulaz, Kuhinja, 1. kat"
+                  placeholderTextColor={colors.textMuted}
+                  editable={!isSubmitting}
+                />
+              </View>
+
+              {isEdit && (
+                <View style={styles.field}>
+                  <Text style={styles.label}>Status</Text>
+                  <View style={styles.chipRow}>
+                    {statusOptions.map((opt) => {
+                      const active = status === opt.value;
+                      return (
+                        <Pressable
+                          key={opt.value}
+                          onPress={() => setStatus(opt.value)}
+                          disabled={isSubmitting}
+                          style={({ pressed }) => [
+                            styles.chip,
+                            active && styles.chipActive,
+                            pressed && !active && styles.chipPressed,
+                          ]}
+                        >
+                          <Text style={[styles.chipText, active && styles.chipTextActive]}>
+                            {opt.label}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                </View>
+              )}
+            </ScrollView>
+
+            <View style={styles.actions}>
+              <Pressable
+                onPress={onClose}
+                disabled={isSubmitting}
+                style={({ pressed }) => [
+                  styles.btn,
+                  styles.btnCancel,
+                  pressed && styles.btnPressed,
+                  isSubmitting && styles.btnDisabled,
+                ]}
+              >
+                <Text style={styles.btnCancelText}>Odustani</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleSubmit}
+                disabled={isSubmitting}
+                style={({ pressed }) => [
+                  styles.btn,
+                  styles.btnSubmit,
+                  pressed && styles.btnPressed,
+                  isSubmitting && styles.btnDisabled,
+                ]}
+              >
+                {isSubmitting ? (
+                  <ActivityIndicator color={colors.bgDeep} />
+                ) : (
+                  <Text style={styles.btnSubmitText}>
+                    {isEdit ? 'Spremi promjene' : 'Dodaj senzor'}
+                  </Text>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.65)',
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 18,
+  },
+  card: {
+    backgroundColor: colors.bgSurface,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radius.card,
+    maxHeight: '90%',
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderSubtle,
+  },
+  title: {
+    ...typography.formHeader,
+    color: colors.textPrimary,
+    fontSize: 16,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 16,
+  },
+  form: {
+    padding: 18,
+    gap: 14,
+  },
+  errorBox: {
+    backgroundColor: colors.errorBg,
+    borderWidth: 1,
+    borderColor: colors.errorBorder,
+    borderRadius: radius.input,
+    padding: 10,
+  },
+  errorText: {
+    ...typography.alert,
+    color: colors.errorText,
+  },
+  field: { gap: 6 },
+  label: {
+    ...typography.label,
+    color: colors.textSecondary,
+  },
+  input: {
+    backgroundColor: colors.bgInput,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radius.input,
+    color: colors.textPrimary,
+    ...typography.input,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    backgroundColor: colors.bgInput,
+  },
+  chipActive: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  chipPressed: {
+    backgroundColor: colors.bgSurface,
+  },
+  chipText: {
+    ...typography.label,
+    color: colors.textSecondary,
+    fontWeight: '500',
+  },
+  chipTextActive: {
+    color: colors.bgDeep,
+    fontWeight: '700',
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 10,
+    padding: 18,
+    borderTopWidth: 1,
+    borderTopColor: colors.borderSubtle,
+  },
+  btn: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: radius.button,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnCancel: {
+    backgroundColor: colors.bgInput,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+  },
+  btnSubmit: {
+    backgroundColor: colors.accent,
+  },
+  btnPressed: { opacity: 0.85 },
+  btnDisabled: { opacity: 0.5 },
+  btnCancelText: {
+    ...typography.button,
+    color: colors.textPrimary,
+    fontSize: 14,
+  },
+  btnSubmitText: {
+    ...typography.button,
+    color: colors.bgDeep,
+  },
+});

--- a/mobile/src/navigation/RootStack.tsx
+++ b/mobile/src/navigation/RootStack.tsx
@@ -7,6 +7,7 @@ import { CamerasScreen } from '../screens/CamerasScreen';
 import { CameraDetailScreen } from '../screens/CameraDetailScreen';
 import { AlarmsScreen } from '../screens/AlarmsScreen';
 import { SensorsScreen } from '../screens/SensorsScreen';
+import { SensorDetailScreen } from '../screens/SensorDetailScreen';
 import {
   AnalyticsScreen,
   UsersScreen,
@@ -20,6 +21,7 @@ export type RootStackParamList = {
   Cameras: undefined;
   CameraDetail: { id: string };
   Sensors: undefined;
+  SensorDetail: { id: string };
   Alarms: undefined;
   Analytics: undefined;
   Users: undefined;
@@ -46,6 +48,7 @@ export function RootStack() {
       <Stack.Screen name="Cameras" component={CamerasScreen} />
       <Stack.Screen name="CameraDetail" component={CameraDetailScreen} />
       <Stack.Screen name="Sensors" component={SensorsScreen} />
+      <Stack.Screen name="SensorDetail" component={SensorDetailScreen} />
       <Stack.Screen name="Alarms" component={AlarmsScreen} />
       <Stack.Screen name="Analytics" component={AnalyticsScreen} />
       <Stack.Screen name="Users" component={UsersScreen} />

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -16,9 +16,9 @@ import { apiFetch } from '../lib/api';
 import { clearAuthSession } from '../lib/auth';
 import {
   mockAlarms,
-  mockSensors,
   alarmTypeBadge,
 } from '../data/mockData';
+import { isOnline as sensorIsOnline } from './SensorsScreen';
 import type { RootStackNavigation } from '../navigation/RootStack';
 
 type Camera = {
@@ -28,32 +28,48 @@ type Camera = {
   isOnline: boolean;
 };
 
+type DashboardSensor = {
+  id: string;
+  name: string;
+  status: 'active' | 'inactive';
+  last_seen: string | null;
+};
+
 export function DashboardScreen() {
   const rootNav = useNavigation<RootStackNavigation>();
   const [cameras, setCameras] = useState<Camera[]>([]);
+  const [sensors, setSensors] = useState<DashboardSensor[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
 
-  const loadCameras = useCallback(async (isRefresh = false) => {
+  const loadData = useCallback(async (isRefresh = false) => {
     if (!isRefresh) setLoading(true);
     setError('');
 
     try {
-      const response = await apiFetch('/api/cameras', { includeAuth: true });
+      const [camRes, senRes] = await Promise.all([
+        apiFetch('/api/cameras', { includeAuth: true }),
+        apiFetch('/api/sensors', { includeAuth: true }),
+      ]);
 
-      if (response.status === 401) {
+      if (camRes.status === 401 || senRes.status === 401) {
         clearAuthSession();
         rootNav.reset({ index: 0, routes: [{ name: 'Login' }] });
         return;
       }
 
-      const data = await response.json();
-      if (!response.ok) {
-        setError(data.message || 'Neuspješno dohvaćanje kamera.');
+      const camData = await camRes.json();
+      if (!camRes.ok) {
+        setError(camData.message || 'Neuspješno dohvaćanje kamera.');
         return;
       }
-      setCameras(data.cameras ?? []);
+      setCameras(camData.cameras ?? []);
+
+      if (senRes.ok) {
+        const senData = await senRes.json();
+        setSensors(senData.sensors ?? []);
+      }
     } catch {
       setError('Greška pri dohvaćanju zaštićenih podataka.');
     } finally {
@@ -63,17 +79,17 @@ export function DashboardScreen() {
   }, [rootNav]);
 
   useEffect(() => {
-    void loadCameras();
-  }, [loadCameras]);
+    void loadData();
+  }, [loadData]);
 
   const onRefresh = useCallback(() => {
     setRefreshing(true);
-    void loadCameras(true);
-  }, [loadCameras]);
+    void loadData(true);
+  }, [loadData]);
 
   const activeCameras = cameras.filter((c) => c.isOnline).length;
-  const activeSensors = mockSensors.filter((s) => s.status === 'active').length;
-  const inactiveSensors = mockSensors.length - activeSensors;
+  const activeSensors = sensors.filter((s) => s.status === 'active').length;
+  const inactiveSensors = sensors.length - activeSensors;
   const unreadAlarms = mockAlarms.length;
   const lastFiveAlarms = mockAlarms.slice(0, 5);
 
@@ -101,7 +117,7 @@ export function DashboardScreen() {
         <StatCard
           variant="sensors"
           label="Aktivni senzori"
-          value={`${activeSensors}/${mockSensors.length}`}
+          value={`${activeSensors}/${sensors.length}`}
         />
         <StatCard
           variant="alarms"
@@ -151,32 +167,46 @@ export function DashboardScreen() {
             Neaktivni: {inactiveSensors}
           </Text>
         </View>
-        {mockSensors.map((sensor) => (
-          <View key={sensor.id} style={styles.sensorItem}>
-            <View
-              style={[
-                styles.sensorDot,
-                {
-                  backgroundColor:
-                    sensor.status === 'active' ? colors.success : colors.textMuted,
-                },
-              ]}
-            />
-            <Text style={styles.sensorName} numberOfLines={1}>
-              {sensor.name}
-            </Text>
-            <Text
-              style={[
-                styles.sensorStatus,
-                {
-                  color: sensor.status === 'active' ? colors.success : colors.textMuted,
-                },
-              ]}
-            >
-              {sensor.status === 'active' ? 'Aktivan' : 'Neaktivan'}
-            </Text>
-          </View>
-        ))}
+        {sensors.length === 0 && !loading && (
+          <Text style={styles.emptyText}>Nema senzora za prikaz.</Text>
+        )}
+        {sensors.map((sensor) => {
+          const online = sensorIsOnline(sensor.last_seen);
+          const isActive = sensor.status === 'active';
+          return (
+            <View key={sensor.id} style={styles.sensorItem}>
+              <View
+                style={[
+                  styles.sensorDot,
+                  {
+                    backgroundColor: isActive
+                      ? online
+                        ? colors.success
+                        : colors.error
+                      : colors.textMuted,
+                  },
+                ]}
+              />
+              <Text style={styles.sensorName} numberOfLines={1}>
+                {sensor.name}
+              </Text>
+              <Text
+                style={[
+                  styles.sensorStatus,
+                  {
+                    color: isActive
+                      ? online
+                        ? colors.success
+                        : colors.error
+                      : colors.textMuted,
+                  },
+                ]}
+              >
+                {isActive ? (online ? 'Online' : 'Offline') : 'Neaktivan'}
+              </Text>
+            </View>
+          );
+        })}
       </View>
 
       {/* Kamere — grid (1 stupac na mobile, prirodno) */}

--- a/mobile/src/screens/SensorDetailScreen.tsx
+++ b/mobile/src/screens/SensorDetailScreen.tsx
@@ -1,0 +1,666 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import Svg, { Path } from 'react-native-svg';
+import { AppScreenLayout } from '../components/AppScreenLayout';
+import { SensorFormModal, type SensorFormData } from '../components/SensorFormModal';
+import { ConfirmModal } from '../components/ConfirmModal';
+import { apiFetch } from '../lib/api';
+import { clearAuthSession } from '../lib/auth';
+import { colors, radius } from '../theme/colors';
+import { typography } from '../theme/typography';
+import { sensorTypeLabels, sensorTypeColors, type SensorType } from '../data/mockData';
+import {
+  SensorIcon,
+  formatLastReading,
+  isOnline,
+  relativeTime,
+  eventTypeLabels,
+} from './SensorsScreen';
+import type { RootStackParamList, RootStackNavigation } from '../navigation/RootStack';
+
+type Sensor = {
+  id: string;
+  name: string;
+  type: SensorType;
+  location: string;
+  status: 'active' | 'inactive';
+  last_seen: string | null;
+  created_at: string;
+};
+
+type DeviceEvent = {
+  id: string;
+  device_id: string;
+  event_type: string;
+  payload: Record<string, unknown>;
+  created_at: string;
+};
+
+type Props = NativeStackScreenProps<RootStackParamList, 'SensorDetail'>;
+
+function eventBadgeColor(eventType: string): string {
+  switch (eventType) {
+    case 'alert':
+      return colors.error;
+    case 'battery_low':
+      return '#fb923c';
+    case 'offline':
+      return colors.textMuted;
+    case 'online':
+      return colors.success;
+    case 'status_change':
+      return '#60a5fa';
+    case 'reading':
+    default:
+      return colors.accent;
+  }
+}
+
+function formatPayload(payload: Record<string, unknown>): string {
+  const keys = Object.keys(payload);
+  if (keys.length === 0) return '—';
+  return keys.map((k) => `${k}: ${JSON.stringify(payload[k])}`).join(', ');
+}
+
+function formatDateTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('hr-HR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function SensorDetailScreen({ route }: Props) {
+  const { id } = route.params;
+  const navigation = useNavigation<RootStackNavigation>();
+
+  const [sensor, setSensor] = useState<Sensor | null>(null);
+  const [events, setEvents] = useState<DeviceEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  const load = useCallback(
+    async (isRefresh = false) => {
+      if (!isRefresh) setLoading(true);
+      setError('');
+
+      try {
+        const [sensorRes, eventsRes] = await Promise.all([
+          apiFetch(`/api/sensors/${id}`, { includeAuth: true }),
+          apiFetch(`/api/sensors/${id}/events?limit=50`, { includeAuth: true }),
+        ]);
+
+        if (sensorRes.status === 401) {
+          clearAuthSession();
+          navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+          return;
+        }
+
+        if (sensorRes.status === 404) {
+          setError('Senzor nije pronađen.');
+          return;
+        }
+
+        const sensorData = await sensorRes.json();
+        if (!sensorRes.ok) {
+          setError(sensorData.message || 'Neuspješno dohvaćanje senzora.');
+          return;
+        }
+        setSensor(sensorData.sensor);
+
+        if (eventsRes.ok) {
+          const eventsData = await eventsRes.json();
+          setEvents(eventsData.events ?? []);
+        }
+      } catch {
+        setError('Greška pri dohvaćanju senzora.');
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [id, navigation]
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    void load(true);
+  }, [load]);
+
+  const handleBack = () => {
+    if (navigation.canGoBack()) navigation.goBack();
+    else navigation.navigate('Sensors');
+  };
+
+  const handleEditSubmit = async (data: SensorFormData) => {
+    const res = await apiFetch(`/api/sensors/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+      includeAuth: true,
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.message || 'Greška pri ažuriranju.');
+    setSensor(json.sensor);
+    setIsFormOpen(false);
+  };
+
+  const handleDeleteConfirm = async () => {
+    const res = await apiFetch(`/api/sensors/${id}`, {
+      method: 'DELETE',
+      includeAuth: true,
+    });
+    if (!res.ok) {
+      const json = await res.json();
+      throw new Error(json.message || 'Greška pri brisanju.');
+    }
+    setIsDeleteOpen(false);
+    navigation.navigate('Sensors');
+  };
+
+  if (loading) {
+    return (
+      <AppScreenLayout title="Senzor">
+        <View style={styles.centered}>
+          <ActivityIndicator color={colors.accent} />
+          <Text style={styles.loaderText}>Učitavanje...</Text>
+        </View>
+      </AppScreenLayout>
+    );
+  }
+
+  if (error || !sensor) {
+    return (
+      <AppScreenLayout title="Senzor">
+        <View style={styles.centered}>
+          <Text style={styles.errorText}>{error || 'Senzor nije dostupan.'}</Text>
+          <Pressable onPress={handleBack} style={styles.backFallbackBtn}>
+            <Text style={styles.backFallbackText}>Povratak na popis senzora</Text>
+          </Pressable>
+        </View>
+      </AppScreenLayout>
+    );
+  }
+
+  const online = isOnline(sensor.last_seen);
+  const isActive = sensor.status === 'active';
+  const typeColor = sensorTypeColors[sensor.type];
+
+  // Za "zadnje očitanje" — uzmi prvi event iz liste (najnoviji prvo)
+  const lastEvent = events[0];
+  const lastReading = lastEvent
+    ? formatLastReading({
+        last_event_type: lastEvent.event_type,
+        last_event_payload: lastEvent.payload,
+      })
+    : '—';
+
+  return (
+    <AppScreenLayout title={sensor.name}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.accent}
+            colors={[colors.accent]}
+          />
+        }
+      >
+        {/* Back + CRUD */}
+        <View style={styles.topBar}>
+          <Pressable onPress={handleBack} hitSlop={8} style={styles.backBtn}>
+            <Svg viewBox="0 0 20 20" width={16} height={16} fill={colors.accent}>
+              <Path
+                fillRule="evenodd"
+                d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 011.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z"
+                clipRule="evenodd"
+              />
+            </Svg>
+            <Text style={styles.backText}>Natrag na senzore</Text>
+          </Pressable>
+
+          <View style={styles.crudActions}>
+            <Pressable
+              onPress={() => setIsFormOpen(true)}
+              style={({ pressed }) => [styles.crudBtn, styles.crudBtnEdit, pressed && styles.crudBtnPressed]}
+              hitSlop={4}
+            >
+              <Svg viewBox="0 0 20 20" width={14} height={14} fill={colors.textPrimary}>
+                <Path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
+              </Svg>
+              <Text style={styles.crudBtnText}>Uredi</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => setIsDeleteOpen(true)}
+              style={({ pressed }) => [styles.crudBtn, styles.crudBtnDelete, pressed && styles.crudBtnPressed]}
+              hitSlop={4}
+            >
+              <Svg viewBox="0 0 20 20" width={14} height={14} fill={colors.textPrimary}>
+                <Path
+                  fillRule="evenodd"
+                  d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z"
+                  clipRule="evenodd"
+                />
+              </Svg>
+              <Text style={styles.crudBtnText}>Obriši</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {/* Hero */}
+        <View style={styles.hero}>
+          <View style={[styles.heroIcon, { backgroundColor: typeColor + '1A' }]}>
+            <SensorIcon type={sensor.type} size={36} />
+          </View>
+          <Text style={styles.heroName}>{sensor.name}</Text>
+          <View style={styles.heroMeta}>
+            <View style={[styles.typeBadge, { backgroundColor: typeColor + '1F' }]}>
+              <Text style={[styles.typeBadgeText, { color: typeColor }]}>
+                {sensorTypeLabels[sensor.type]}
+              </Text>
+            </View>
+            <View style={styles.locationRow}>
+              <Svg viewBox="0 0 20 20" width={12} height={12} fill={colors.textMuted}>
+                <Path
+                  fillRule="evenodd"
+                  d="M9.69 18.933l.003.001C9.89 19.02 10 19 10 19s.11.02.308-.066l.002-.001.006-.003.018-.008a5.741 5.741 0 00.281-.14c.186-.096.446-.24.757-.433.62-.384 1.445-.966 2.274-1.765C15.302 14.988 17 12.493 17 9A7 7 0 103 9c0 3.492 1.698 5.988 3.355 7.584a13.731 13.731 0 002.273 1.765 11.842 11.842 0 00.976.544l.062.029.018.008.006.003zM10 11.25a2.25 2.25 0 100-4.5 2.25 2.25 0 000 4.5z"
+                  clipRule="evenodd"
+                />
+              </Svg>
+              <Text style={styles.locationText}>{sensor.location}</Text>
+            </View>
+          </View>
+          <View style={styles.pillsRow}>
+            <View style={[styles.pill, isActive ? styles.pillActive : styles.pillInactive]}>
+              <View style={[styles.pillDot, { backgroundColor: isActive ? colors.success : colors.textMuted }]} />
+              <Text style={[styles.pillText, { color: isActive ? colors.success : colors.textMuted }]}>
+                {isActive ? 'Aktivan' : 'Neaktivan'}
+              </Text>
+            </View>
+            <View style={[styles.pill, online ? styles.pillOnline : styles.pillOffline]}>
+              <View style={[styles.pillDot, { backgroundColor: online ? colors.success : colors.error }]} />
+              <Text style={[styles.pillText, { color: online ? colors.success : colors.error }]}>
+                {online ? 'Online' : 'Offline'}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        {/* Brzi info panel */}
+        <View style={styles.panel}>
+          <Text style={styles.panelTitle}>Informacije</Text>
+          <View style={styles.divider} />
+          <DetailRow label="Zadnje očitanje" value={lastReading} />
+          <DetailRow
+            label="Zadnji signal"
+            value={sensor.last_seen ? relativeTime(sensor.last_seen) : 'Nikad'}
+          />
+          <DetailRow label="Kreiran" value={formatDateTime(sensor.created_at)} />
+        </View>
+
+        {/* Događaji */}
+        <View style={styles.panel}>
+          <View style={styles.eventsHeader}>
+            <Text style={styles.panelTitle}>Događaji</Text>
+            <Text style={styles.eventsCount}>
+              {events.length} {events.length === 1 ? 'događaj' : 'događaja'}
+            </Text>
+          </View>
+          <View style={styles.divider} />
+          {events.length === 0 && (
+            <Text style={styles.emptyEvents}>Nema zabilježenih događaja.</Text>
+          )}
+          {events.map((ev) => {
+            const tone = eventBadgeColor(ev.event_type);
+            return (
+              <View key={ev.id} style={styles.eventItem}>
+                <View style={[styles.eventBadge, { borderColor: tone }]}>
+                  <Text style={[styles.eventBadgeText, { color: tone }]} numberOfLines={1}>
+                    {eventTypeLabels[ev.event_type] ?? ev.event_type}
+                  </Text>
+                </View>
+                <View style={styles.eventBody}>
+                  <Text style={styles.eventPayload} numberOfLines={2}>
+                    {formatPayload(ev.payload)}
+                  </Text>
+                  <Text style={styles.eventTime}>{formatDateTime(ev.created_at)}</Text>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      </ScrollView>
+
+      {/* CRUD modali */}
+      <SensorFormModal
+        visible={isFormOpen}
+        onClose={() => setIsFormOpen(false)}
+        onSubmit={handleEditSubmit}
+        isEdit
+        initialData={{
+          name: sensor.name,
+          type: sensor.type,
+          location: sensor.location,
+          status: sensor.status,
+        }}
+      />
+
+      <ConfirmModal
+        visible={isDeleteOpen}
+        title="Obrisati senzor?"
+        message={`Jeste li sigurni da želite obrisati senzor "${sensor.name}"? Svi povezani događaji će također biti obrisani.`}
+        confirmText="Obriši"
+        danger
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setIsDeleteOpen(false)}
+      />
+    </AppScreenLayout>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.detailRow}>
+      <Text style={styles.detailLabel}>{label}</Text>
+      <Text style={styles.detailValue} numberOfLines={1}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: { flex: 1, backgroundColor: colors.bgDeep },
+  content: {
+    padding: 16,
+    paddingBottom: 32,
+    gap: 14,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 24,
+    backgroundColor: colors.bgDeep,
+  },
+  loaderText: {
+    ...typography.formSubheader,
+    color: colors.textSecondary,
+  },
+  errorText: {
+    ...typography.formSubheader,
+    color: colors.errorText,
+    textAlign: 'center',
+  },
+  backFallbackBtn: {
+    marginTop: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: radius.button,
+    backgroundColor: colors.accent,
+  },
+  backFallbackText: {
+    ...typography.button,
+    color: colors.bgDeep,
+  },
+
+  topBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 10,
+    flexWrap: 'wrap',
+  },
+  backBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 4,
+  },
+  backText: {
+    ...typography.link,
+    color: colors.accent,
+  },
+  crudActions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  crudBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: radius.button,
+    borderWidth: 1,
+  },
+  crudBtnEdit: {
+    backgroundColor: colors.bgSurface,
+    borderColor: colors.borderSubtle,
+  },
+  crudBtnDelete: {
+    backgroundColor: colors.errorBg,
+    borderColor: colors.errorBorder,
+  },
+  crudBtnPressed: { opacity: 0.75 },
+  crudBtnText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.textPrimary,
+  },
+
+  // Hero
+  hero: {
+    backgroundColor: colors.bgSurface,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radius.card,
+    padding: 18,
+    alignItems: 'center',
+    gap: 10,
+  },
+  heroIcon: {
+    width: 64,
+    height: 64,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroName: {
+    ...typography.formHeader,
+    color: colors.textPrimary,
+    fontSize: 17,
+    textAlign: 'center',
+  },
+  heroMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  typeBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 4,
+  },
+  typeBadgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  locationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  locationText: {
+    ...typography.formSubheader,
+    color: colors.textMuted,
+    fontSize: 12,
+  },
+
+  pillsRow: {
+    flexDirection: 'row',
+    gap: 6,
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  pillActive: {
+    backgroundColor: 'rgba(90, 207, 122, 0.1)',
+    borderColor: 'rgba(90, 207, 122, 0.25)',
+  },
+  pillInactive: {
+    backgroundColor: 'rgba(107, 114, 128, 0.1)',
+    borderColor: 'rgba(107, 114, 128, 0.2)',
+  },
+  pillOnline: {
+    backgroundColor: 'rgba(90, 207, 122, 0.1)',
+    borderColor: 'rgba(90, 207, 122, 0.25)',
+  },
+  pillOffline: {
+    backgroundColor: 'rgba(229, 77, 77, 0.1)',
+    borderColor: 'rgba(229, 77, 77, 0.25)',
+  },
+  pillDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  pillText: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+  },
+
+  // Panels
+  panel: {
+    backgroundColor: colors.bgSurface,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radius.card,
+    padding: 16,
+  },
+  panelTitle: {
+    ...typography.formHeader,
+    color: colors.textPrimary,
+    fontSize: 16,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.borderSubtle,
+    marginVertical: 12,
+  },
+
+  // Detail row
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+    gap: 12,
+  },
+  detailLabel: {
+    ...typography.label,
+    color: colors.textMuted,
+  },
+  detailValue: {
+    ...typography.formSubheader,
+    color: colors.textPrimary,
+    fontWeight: '500',
+    maxWidth: '65%',
+    textAlign: 'right',
+  },
+
+  // Events
+  eventsHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  eventsCount: {
+    ...typography.label,
+    color: colors.textMuted,
+  },
+  emptyEvents: {
+    ...typography.formSubheader,
+    color: colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: 16,
+  },
+  eventItem: {
+    flexDirection: 'row',
+    gap: 10,
+    paddingVertical: 10,
+    borderTopWidth: 1,
+    borderTopColor: colors.borderSubtle,
+  },
+  eventBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    borderWidth: 1,
+    backgroundColor: colors.bgInput,
+    alignSelf: 'flex-start',
+    minWidth: 80,
+    alignItems: 'center',
+  },
+  eventBadgeText: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+  },
+  eventBody: {
+    flex: 1,
+    gap: 3,
+  },
+  eventPayload: {
+    ...typography.formSubheader,
+    color: colors.textPrimary,
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  eventTime: {
+    ...typography.label,
+    color: colors.textMuted,
+    fontSize: 11,
+  },
+});

--- a/mobile/src/screens/SensorsScreen.tsx
+++ b/mobile/src/screens/SensorsScreen.tsx
@@ -1,29 +1,99 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   ScrollView,
+  ActivityIndicator,
   Pressable,
+  RefreshControl,
 } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import Svg, { Path, Rect, Circle, Line } from 'react-native-svg';
 import { AppScreenLayout } from '../components/AppScreenLayout';
+import { SensorFormModal, type SensorFormData } from '../components/SensorFormModal';
+import { ConfirmModal } from '../components/ConfirmModal';
+import { ApiKeyModal } from '../components/ApiKeyModal';
+import { apiFetch } from '../lib/api';
+import { clearAuthSession } from '../lib/auth';
 import { colors, radius } from '../theme/colors';
 import { typography } from '../theme/typography';
 import {
-  mockSensors,
   sensorTypeLabels,
   sensorTypeColors,
   type SensorType,
-  type SensorStatus,
 } from '../data/mockData';
+import type { RootStackNavigation } from '../navigation/RootStack';
+
+/* ===== Tipovi ===== */
+type SensorStatus = 'active' | 'inactive';
+
+export type Sensor = {
+  id: string;
+  name: string;
+  type: SensorType;
+  location: string;
+  status: SensorStatus;
+  last_seen: string | null;
+  created_at: string;
+  last_event_type: string | null;
+  last_event_payload: Record<string, unknown> | null;
+  last_event_time: string | null;
+};
 
 type FilterType = 'all' | SensorType;
 type FilterStatus = 'all' | SensorStatus;
+type FilterConnection = 'all' | 'online' | 'offline';
 
-function SensorIcon({ type, size = 20 }: { type: SensorType; size?: number }) {
+const ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
+
+export function isOnline(lastSeen: string | null): boolean {
+  if (!lastSeen) return false;
+  return Date.now() - new Date(lastSeen).getTime() < ONLINE_THRESHOLD_MS;
+}
+
+export function formatLastReading(sensor: {
+  last_event_type: string | null;
+  last_event_payload: Record<string, unknown> | null;
+}): string {
+  if (!sensor.last_event_payload || !sensor.last_event_type) return '—';
+  const p = sensor.last_event_payload;
+  if (p.temperature !== undefined) {
+    const temp = `${p.temperature} °C`;
+    return p.humidity !== undefined ? `${temp} / ${p.humidity}%` : temp;
+  }
+  if (p.state !== undefined) return String(p.state) === 'open' ? 'Otvoreno' : 'Zatvoreno';
+  if (p.smoke_level !== undefined) return Number(p.smoke_level) > 0.5 ? 'Dim detektiran!' : 'OK';
+  if (p.motion !== undefined) return p.motion ? 'Pokret!' : 'Mirno';
+  if (p.level !== undefined) return `Baterija: ${p.level}%`;
+  if (p.message !== undefined) return String(p.message);
+  return eventTypeLabels[sensor.last_event_type] ?? '—';
+}
+
+export function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return 'Upravo';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `Prije ${min} min`;
+  const hrs = Math.floor(min / 60);
+  if (hrs < 24) return `Prije ${hrs}h`;
+  return new Date(dateStr).toLocaleDateString('hr-HR');
+}
+
+export const eventTypeLabels: Record<string, string> = {
+  reading: 'Očitanje',
+  alert: 'Upozorenje',
+  status_change: 'Promjena statusa',
+  battery_low: 'Slaba baterija',
+  offline: 'Offline',
+  online: 'Online',
+};
+
+/* ===== Ikona po tipu ===== */
+export function SensorIcon({ type, size = 20 }: { type: SensorType; size?: number }) {
   const color = sensorTypeColors[type];
-  const props = {
+  const p = {
     width: size,
     height: size,
     viewBox: '0 0 24 24' as const,
@@ -33,11 +103,10 @@ function SensorIcon({ type, size = 20 }: { type: SensorType; size?: number }) {
     strokeLinecap: 'round' as const,
     strokeLinejoin: 'round' as const,
   };
-
   switch (type) {
     case 'door':
       return (
-        <Svg {...props}>
+        <Svg {...p}>
           <Path d="M4 20h16" />
           <Path d="M6 20V4h12v16" />
           <Circle cx={15} cy={12} r={0.8} fill={color} stroke="none" />
@@ -45,14 +114,14 @@ function SensorIcon({ type, size = 20 }: { type: SensorType; size?: number }) {
       );
     case 'window':
       return (
-        <Svg {...props}>
+        <Svg {...p}>
           <Rect x={4} y={4} width={16} height={16} rx={1.5} />
           <Path d="M4 12h16M12 4v16" />
         </Svg>
       );
     case 'smoke':
       return (
-        <Svg {...props}>
+        <Svg {...p}>
           <Path d="M5 18c0-1.5 1-2 2-2s2 .5 2 2" />
           <Path d="M9 14c0-1.5 1.2-2.3 2.5-2.3s2.5.8 2.5 2.3" />
           <Path d="M13 10c0-1.8 1.3-2.8 3-2.8s3 1 3 2.8" />
@@ -61,14 +130,14 @@ function SensorIcon({ type, size = 20 }: { type: SensorType; size?: number }) {
       );
     case 'temperature':
       return (
-        <Svg {...props}>
+        <Svg {...p}>
           <Path d="M14 14.76V5a2 2 0 1 0-4 0v9.76a4 4 0 1 0 4 0z" />
           <Line x1={12} y1={9} x2={12} y2={15} />
         </Svg>
       );
     case 'motion':
       return (
-        <Svg {...props}>
+        <Svg {...p}>
           <Circle cx={12} cy={5} r={1.6} />
           <Path d="M10 22l2-6 2 6" />
           <Path d="M8 12l4-3 4 3-2 4h-4z" />
@@ -93,51 +162,189 @@ const statusFilterOptions: { key: FilterStatus; label: string }[] = [
   { key: 'inactive', label: 'Neaktivni' },
 ];
 
+const connectionFilterOptions: { key: FilterConnection; label: string }[] = [
+  { key: 'all', label: 'Svi' },
+  { key: 'online', label: 'Online' },
+  { key: 'offline', label: 'Offline' },
+];
+
 export function SensorsScreen() {
+  const navigation = useNavigation<RootStackNavigation>();
+  const [sensors, setSensors] = useState<Sensor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+
   const [filterType, setFilterType] = useState<FilterType>('all');
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
+  const [filterConnection, setFilterConnection] = useState<FilterConnection>('all');
+
+  // CRUD modali
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingSensor, setEditingSensor] = useState<Sensor | null>(null);
+  const [deletingSensor, setDeletingSensor] = useState<Sensor | null>(null);
+  const [createdApiKey, setCreatedApiKey] = useState<string | null>(null);
+
+  const fetchSensors = useCallback(
+    async (isRefresh = false) => {
+      if (!isRefresh) setLoading(true);
+      setError('');
+      try {
+        const res = await apiFetch('/api/sensors', { includeAuth: true });
+
+        if (res.status === 401) {
+          clearAuthSession();
+          navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+          return;
+        }
+
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.message || 'Neuspješno dohvaćanje senzora.');
+          return;
+        }
+        setSensors(data.sensors ?? []);
+      } catch {
+        setError('Greška pri dohvaćanju senzora.');
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [navigation]
+  );
+
+  useEffect(() => {
+    void fetchSensors();
+  }, [fetchSensors]);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    void fetchSensors(true);
+  }, [fetchSensors]);
+
+  const handleAdd = () => {
+    setEditingSensor(null);
+    setIsFormOpen(true);
+  };
+
+  const handleEdit = (sensor: Sensor) => {
+    setEditingSensor(sensor);
+    setIsFormOpen(true);
+  };
+
+  const handleFormSubmit = async (data: SensorFormData) => {
+    if (editingSensor) {
+      const res = await apiFetch(`/api/sensors/${editingSensor.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+        includeAuth: true,
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.message || 'Greška pri ažuriranju.');
+      setIsFormOpen(false);
+      setEditingSensor(null);
+      await fetchSensors(true);
+    } else {
+      const res = await apiFetch('/api/sensors', {
+        method: 'POST',
+        body: JSON.stringify(data),
+        includeAuth: true,
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.message || 'Greška pri dodavanju.');
+      setIsFormOpen(false);
+      setCreatedApiKey(json.sensor?.api_key ?? null);
+      await fetchSensors(true);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deletingSensor) return;
+    const res = await apiFetch(`/api/sensors/${deletingSensor.id}`, {
+      method: 'DELETE',
+      includeAuth: true,
+    });
+    if (!res.ok) {
+      const json = await res.json();
+      throw new Error(json.message || 'Greška pri brisanju.');
+    }
+    setDeletingSensor(null);
+    await fetchSensors(true);
+  };
 
   const filtered = useMemo(
     () =>
-      mockSensors.filter((s) => {
+      sensors.filter((s) => {
         if (filterType !== 'all' && s.type !== filterType) return false;
         if (filterStatus !== 'all' && s.status !== filterStatus) return false;
+        if (filterConnection !== 'all') {
+          const online = isOnline(s.last_seen);
+          if (filterConnection === 'online' && !online) return false;
+          if (filterConnection === 'offline' && online) return false;
+        }
         return true;
       }),
-    [filterType, filterStatus],
+    [sensors, filterType, filterStatus, filterConnection]
   );
 
-  const activeCount = mockSensors.filter((s) => s.status === 'active').length;
-  const inactiveCount = mockSensors.length - activeCount;
+  const activeCount = sensors.filter((s) => s.status === 'active').length;
+  const inactiveCount = sensors.length - activeCount;
+  const onlineCount = sensors.filter((s) => isOnline(s.last_seen)).length;
+  const offlineCount = sensors.length - onlineCount;
 
   return (
     <AppScreenLayout title="Senzori">
       <ScrollView
         style={styles.scroll}
         contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.accent}
+            colors={[colors.accent]}
+          />
+        }
       >
         {/* Intro */}
         <View style={styles.intro}>
           <Text style={styles.title}>IoT Senzori</Text>
-          <Text style={styles.subtitle}>Pregled svih senzora u sustavu</Text>
+          <Text style={styles.subtitle}>Pregled i upravljanje senzorima u sustavu</Text>
         </View>
+
+        {/* Dodaj senzor */}
+        <Pressable
+          onPress={handleAdd}
+          style={({ pressed }) => [styles.addBtn, pressed && styles.addBtnPressed]}
+        >
+          <Svg viewBox="0 0 20 20" width={16} height={16} fill={colors.bgDeep}>
+            <Path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
+          </Svg>
+          <Text style={styles.addBtnText}>Dodaj senzor</Text>
+        </Pressable>
 
         {/* Stats */}
         <View style={styles.stats}>
           <View style={styles.statPill}>
             <Text style={styles.statLabel}>Ukupno</Text>
-            <Text style={styles.statValue}>{mockSensors.length}</Text>
+            <Text style={styles.statValue}>{sensors.length}</Text>
           </View>
-          <View style={[styles.statPill, styles.statPillActive]}>
-            <View style={[styles.statDot, styles.statDotActive]} />
-            <Text style={[styles.statLabel, styles.statLabelActive]}>Aktivni</Text>
-            <Text style={[styles.statValue, styles.statValueActive]}>{activeCount}</Text>
+          <View style={[styles.statPill, styles.statPillOnline]}>
+            <Text style={[styles.statLabel, styles.statLabelOnline]}>Online</Text>
+            <Text style={[styles.statValue, styles.statValueOnline]}>{onlineCount}</Text>
           </View>
-          <View style={[styles.statPill, styles.statPillInactive]}>
-            <View style={[styles.statDot, styles.statDotInactive]} />
-            <Text style={[styles.statLabel, styles.statLabelInactive]}>Neaktivni</Text>
-            <Text style={[styles.statValue, styles.statValueInactive]}>{inactiveCount}</Text>
+          <View style={[styles.statPill, styles.statPillOffline]}>
+            <Text style={[styles.statLabel, styles.statLabelOffline]}>Offline</Text>
+            <Text style={[styles.statValue, styles.statValueOffline]}>{offlineCount}</Text>
           </View>
+        </View>
+
+        <View style={styles.statsSecondary}>
+          <Text style={styles.statsSecondaryText}>
+            Aktivni: <Text style={styles.statsSecondaryActive}>{activeCount}</Text>  ·  Neaktivni:{' '}
+            <Text style={styles.statsSecondaryInactive}>{inactiveCount}</Text>
+          </Text>
         </View>
 
         {/* Filteri */}
@@ -146,23 +353,12 @@ export function SensorsScreen() {
             <Text style={styles.filterGroupLabel}>Tip</Text>
             <View style={styles.filterRow}>
               {typeFilterOptions.map((opt) => (
-                <Pressable
+                <FilterChip
                   key={opt.key}
+                  label={opt.label}
+                  active={filterType === opt.key}
                   onPress={() => setFilterType(opt.key)}
-                  style={[
-                    styles.filterBtn,
-                    filterType === opt.key && styles.filterBtnActive,
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.filterBtnText,
-                      filterType === opt.key && styles.filterBtnTextActive,
-                    ]}
-                  >
-                    {opt.label}
-                  </Text>
-                </Pressable>
+                />
               ))}
             </View>
           </View>
@@ -171,81 +367,109 @@ export function SensorsScreen() {
             <Text style={styles.filterGroupLabel}>Status</Text>
             <View style={styles.filterRow}>
               {statusFilterOptions.map((opt) => (
-                <Pressable
+                <FilterChip
                   key={opt.key}
+                  label={opt.label}
+                  active={filterStatus === opt.key}
                   onPress={() => setFilterStatus(opt.key)}
-                  style={[
-                    styles.filterBtn,
-                    filterStatus === opt.key && styles.filterBtnActive,
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.filterBtnText,
-                      filterStatus === opt.key && styles.filterBtnTextActive,
-                    ]}
-                  >
-                    {opt.label}
-                  </Text>
-                </Pressable>
+                />
+              ))}
+            </View>
+          </View>
+          <View style={styles.filterDivider} />
+          <View style={styles.filterGroup}>
+            <Text style={styles.filterGroupLabel}>Veza</Text>
+            <View style={styles.filterRow}>
+              {connectionFilterOptions.map((opt) => (
+                <FilterChip
+                  key={opt.key}
+                  label={opt.label}
+                  active={filterConnection === opt.key}
+                  onPress={() => setFilterConnection(opt.key)}
+                />
               ))}
             </View>
           </View>
         </View>
 
-        {/* Empty */}
-        {filtered.length === 0 && (
-          <View style={styles.empty}>
-            <Text style={styles.emptyText}>
-              Nema senzora za prikaz s trenutnim filterima.
-            </Text>
+        {!!error && (
+          <View style={styles.errorBox}>
+            <Text style={styles.errorText}>{error}</Text>
           </View>
         )}
 
-        {/* Kartice */}
-        {filtered.length > 0 && (
+        {loading && (
+          <View style={styles.loader}>
+            <ActivityIndicator color={colors.accent} />
+            <Text style={styles.loaderText}>Učitavanje senzora...</Text>
+          </View>
+        )}
+
+        {!loading && !error && filtered.length === 0 && (
+          <View style={styles.empty}>
+            <Text style={styles.emptyText}>Nema senzora za prikaz s trenutnim filterima.</Text>
+          </View>
+        )}
+
+        {!loading && filtered.length > 0 && (
           <View style={styles.grid}>
             {filtered.map((sensor) => {
               const typeColor = sensorTypeColors[sensor.type];
               const isActive = sensor.status === 'active';
+              const online = isOnline(sensor.last_seen);
 
               return (
-                <View
+                <Pressable
                   key={sensor.id}
-                  style={[styles.card, !isActive && styles.cardInactive]}
+                  onPress={() => navigation.navigate('SensorDetail', { id: sensor.id })}
+                  style={({ pressed }) => [
+                    styles.card,
+                    !isActive && styles.cardInactive,
+                    pressed && styles.cardPressed,
+                  ]}
                 >
                   {/* Card header */}
                   <View style={styles.cardHeader}>
-                    <View
-                      style={[
-                        styles.iconWrap,
-                        { backgroundColor: typeColor + '1A' },
-                      ]}
-                    >
+                    <View style={[styles.iconWrap, { backgroundColor: typeColor + '1A' }]}>
                       <SensorIcon type={sensor.type} />
                     </View>
-                    <View
-                      style={[
-                        styles.statusPill,
-                        isActive ? styles.statusPillActive : styles.statusPillInactive,
-                      ]}
-                    >
-                      <View
-                        style={[
-                          styles.statusDot,
-                          {
-                            backgroundColor: isActive ? colors.success : colors.textMuted,
-                          },
-                        ]}
-                      />
-                      <Text
-                        style={[
-                          styles.statusText,
-                          { color: isActive ? colors.success : colors.textMuted },
+
+                    <View style={styles.cardActions}>
+                      <Pressable
+                        onPress={(e) => {
+                          e.stopPropagation();
+                          handleEdit(sensor);
+                        }}
+                        hitSlop={6}
+                        style={({ pressed }) => [
+                          styles.cardActionBtn,
+                          pressed && styles.cardActionBtnPressed,
                         ]}
                       >
-                        {isActive ? 'Aktivan' : 'Neaktivan'}
-                      </Text>
+                        <Svg viewBox="0 0 20 20" width={14} height={14} fill={colors.textPrimary}>
+                          <Path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
+                        </Svg>
+                      </Pressable>
+                      <Pressable
+                        onPress={(e) => {
+                          e.stopPropagation();
+                          setDeletingSensor(sensor);
+                        }}
+                        hitSlop={6}
+                        style={({ pressed }) => [
+                          styles.cardActionBtn,
+                          styles.cardActionBtnDelete,
+                          pressed && styles.cardActionBtnPressed,
+                        ]}
+                      >
+                        <Svg viewBox="0 0 20 20" width={14} height={14} fill={colors.textPrimary}>
+                          <Path
+                            fillRule="evenodd"
+                            d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z"
+                            clipRule="evenodd"
+                          />
+                        </Svg>
+                      </Pressable>
                     </View>
                   </View>
 
@@ -253,12 +477,7 @@ export function SensorsScreen() {
                   <View style={styles.cardBody}>
                     <Text style={styles.cardName}>{sensor.name}</Text>
                     <View style={styles.cardMeta}>
-                      <View
-                        style={[
-                          styles.typeBadge,
-                          { backgroundColor: typeColor + '1F' },
-                        ]}
-                      >
+                      <View style={[styles.typeBadge, { backgroundColor: typeColor + '1F' }]}>
                         <Text style={[styles.typeBadgeText, { color: typeColor }]}>
                           {sensorTypeLabels[sensor.type]}
                         </Text>
@@ -271,25 +490,136 @@ export function SensorsScreen() {
                             clipRule="evenodd"
                           />
                         </Svg>
-                        <Text style={styles.locationText}>{sensor.location}</Text>
+                        <Text style={styles.locationText} numberOfLines={1}>
+                          {sensor.location}
+                        </Text>
                       </View>
                     </View>
                   </View>
 
-                  {/* Card footer */}
-                  <View style={styles.cardFooter}>
-                    <Text style={styles.readingLabel}>Zadnje ocitanje</Text>
-                    <Text style={styles.readingValue}>
-                      {sensor.lastReading ?? '—'}
-                    </Text>
+                  {/* Pills row */}
+                  <View style={styles.pillsRow}>
+                    <View
+                      style={[
+                        styles.pill,
+                        isActive ? styles.pillActive : styles.pillInactive,
+                      ]}
+                    >
+                      <View
+                        style={[
+                          styles.pillDot,
+                          { backgroundColor: isActive ? colors.success : colors.textMuted },
+                        ]}
+                      />
+                      <Text
+                        style={[
+                          styles.pillText,
+                          { color: isActive ? colors.success : colors.textMuted },
+                        ]}
+                      >
+                        {isActive ? 'Aktivan' : 'Neaktivan'}
+                      </Text>
+                    </View>
+                    <View
+                      style={[
+                        styles.pill,
+                        online ? styles.pillOnline : styles.pillOffline,
+                      ]}
+                    >
+                      <View
+                        style={[
+                          styles.pillDot,
+                          { backgroundColor: online ? colors.success : colors.error },
+                        ]}
+                      />
+                      <Text
+                        style={[
+                          styles.pillText,
+                          { color: online ? colors.success : colors.error },
+                        ]}
+                      >
+                        {online ? 'Online' : 'Offline'}
+                      </Text>
+                    </View>
                   </View>
-                </View>
+
+                  {/* Footer — zadnje očitanje */}
+                  <View style={styles.cardFooter}>
+                    <View>
+                      <Text style={styles.readingLabel}>Zadnje očitanje</Text>
+                      <Text style={styles.readingValue}>{formatLastReading(sensor)}</Text>
+                    </View>
+                    {sensor.last_seen && (
+                      <Text style={styles.lastSeen}>{relativeTime(sensor.last_seen)}</Text>
+                    )}
+                  </View>
+                </Pressable>
               );
             })}
           </View>
         )}
       </ScrollView>
+
+      {/* Modali */}
+      <SensorFormModal
+        visible={isFormOpen}
+        onClose={() => {
+          setIsFormOpen(false);
+          setEditingSensor(null);
+        }}
+        onSubmit={handleFormSubmit}
+        isEdit={!!editingSensor}
+        initialData={
+          editingSensor
+            ? {
+                name: editingSensor.name,
+                type: editingSensor.type,
+                location: editingSensor.location,
+                status: editingSensor.status,
+              }
+            : null
+        }
+      />
+
+      <ConfirmModal
+        visible={!!deletingSensor}
+        title="Obrisati senzor?"
+        message={`Jeste li sigurni da želite obrisati senzor "${deletingSensor?.name ?? ''}"? Svi povezani događaji će također biti obrisani.`}
+        confirmText="Obriši"
+        danger
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeletingSensor(null)}
+      />
+
+      <ApiKeyModal
+        visible={!!createdApiKey}
+        apiKey={createdApiKey}
+        onClose={() => setCreatedApiKey(null)}
+      />
     </AppScreenLayout>
+  );
+}
+
+function FilterChip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.filterBtn,
+        active && styles.filterBtnActive,
+        pressed && !active && styles.filterBtnPressed,
+      ]}
+    >
+      <Text style={[styles.filterBtnText, active && styles.filterBtnTextActive]}>{label}</Text>
+    </Pressable>
   );
 }
 
@@ -300,9 +630,7 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     gap: 14,
   },
-  intro: {
-    gap: 2,
-  },
+  intro: { gap: 2 },
   title: {
     ...typography.formHeader,
     color: colors.textPrimary,
@@ -310,6 +638,23 @@ const styles = StyleSheet.create({
   subtitle: {
     ...typography.formSubheader,
     color: colors.textMuted,
+  },
+
+  // Dodaj gumb
+  addBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: radius.button,
+    backgroundColor: colors.accent,
+  },
+  addBtnPressed: { opacity: 0.85 },
+  addBtnText: {
+    ...typography.button,
+    color: colors.bgDeep,
   },
 
   // Stats
@@ -326,42 +671,41 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 12,
     alignItems: 'center',
-    gap: 4,
   },
-  statPillActive: {
+  statPillOnline: {
     borderColor: colors.successBorder,
     backgroundColor: colors.successBg,
   },
-  statPillInactive: {
-    borderColor: colors.borderSubtle,
-    backgroundColor: colors.bgSurface,
-  },
-  statDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-  },
-  statDotActive: {
-    backgroundColor: colors.success,
-  },
-  statDotInactive: {
-    backgroundColor: colors.textMuted,
+  statPillOffline: {
+    borderColor: colors.errorBorder,
+    backgroundColor: colors.errorBg,
   },
   statLabel: {
     ...typography.label,
     color: colors.textMuted,
-    fontSize: 10,
+    fontSize: 11,
     letterSpacing: 0.5,
   },
-  statLabelActive: { color: colors.successText },
-  statLabelInactive: { color: colors.textMuted },
+  statLabelOnline: { color: colors.successText },
+  statLabelOffline: { color: colors.errorText },
   statValue: {
     ...typography.formHeader,
     color: colors.textPrimary,
     fontSize: 18,
+    marginTop: 2,
   },
-  statValueActive: { color: colors.successText },
-  statValueInactive: { color: colors.textMuted },
+  statValueOnline: { color: colors.successText },
+  statValueOffline: { color: colors.errorText },
+
+  statsSecondary: {
+    alignItems: 'center',
+  },
+  statsSecondaryText: {
+    ...typography.label,
+    color: colors.textMuted,
+  },
+  statsSecondaryActive: { color: colors.success, fontWeight: '700' },
+  statsSecondaryInactive: { color: colors.textMuted, fontWeight: '700' },
 
   // Filteri
   filtersCard: {
@@ -372,9 +716,7 @@ const styles = StyleSheet.create({
     padding: 14,
     gap: 10,
   },
-  filterGroup: {
-    gap: 8,
-  },
+  filterGroup: { gap: 8 },
   filterGroupLabel: {
     ...typography.label,
     color: colors.textMuted,
@@ -402,6 +744,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.accentSoft,
     borderColor: colors.accentGlow,
   },
+  filterBtnPressed: {
+    backgroundColor: colors.bgInput,
+  },
   filterBtnText: {
     ...typography.formSubheader,
     color: colors.textSecondary,
@@ -412,7 +757,29 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 
-  // Empty
+  // States
+  errorBox: {
+    backgroundColor: colors.errorBg,
+    borderWidth: 1,
+    borderColor: colors.errorBorder,
+    borderRadius: radius.input,
+    padding: 12,
+  },
+  errorText: {
+    ...typography.alert,
+    color: colors.errorText,
+  },
+  loader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 24,
+  },
+  loaderText: {
+    ...typography.formSubheader,
+    color: colors.textSecondary,
+  },
   empty: {
     paddingVertical: 40,
     alignItems: 'center',
@@ -423,12 +790,8 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 
-  // Grid
-  grid: {
-    gap: 12,
-  },
-
-  // Card
+  // Cards
+  grid: { gap: 12 },
   card: {
     backgroundColor: colors.bgSurface,
     borderWidth: 1,
@@ -437,8 +800,9 @@ const styles = StyleSheet.create({
     padding: 14,
     gap: 12,
   },
-  cardInactive: {
-    opacity: 0.7,
+  cardInactive: { opacity: 0.7 },
+  cardPressed: {
+    borderColor: colors.accent,
   },
   cardHeader: {
     flexDirection: 'row',
@@ -452,38 +816,27 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  statusPill: {
+  cardActions: {
     flexDirection: 'row',
-    alignItems: 'center',
     gap: 6,
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 999,
+  },
+  cardActionBtn: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgInput,
     borderWidth: 1,
+    borderColor: colors.borderSubtle,
   },
-  statusPillActive: {
-    backgroundColor: 'rgba(52, 211, 153, 0.1)',
-    borderColor: 'rgba(52, 211, 153, 0.25)',
+  cardActionBtnDelete: {
+    backgroundColor: colors.errorBg,
+    borderColor: colors.errorBorder,
   },
-  statusPillInactive: {
-    backgroundColor: 'rgba(107, 114, 128, 0.1)',
-    borderColor: 'rgba(107, 114, 128, 0.2)',
-  },
-  statusDot: {
-    width: 6,
-    height: 6,
-    borderRadius: 3,
-  },
-  statusText: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.3,
-  },
+  cardActionBtnPressed: { opacity: 0.7 },
 
-  // Card body
-  cardBody: {
-    gap: 8,
-  },
+  cardBody: { gap: 8 },
   cardName: {
     ...typography.formSubheader,
     color: colors.textPrimary,
@@ -511,6 +864,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
+    flexShrink: 1,
   },
   locationText: {
     ...typography.formSubheader,
@@ -518,7 +872,47 @@ const styles = StyleSheet.create({
     fontSize: 12,
   },
 
-  // Card footer
+  pillsRow: {
+    flexDirection: 'row',
+    gap: 6,
+    flexWrap: 'wrap',
+  },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  pillActive: {
+    backgroundColor: 'rgba(90, 207, 122, 0.1)',
+    borderColor: 'rgba(90, 207, 122, 0.25)',
+  },
+  pillInactive: {
+    backgroundColor: 'rgba(107, 114, 128, 0.1)',
+    borderColor: 'rgba(107, 114, 128, 0.2)',
+  },
+  pillOnline: {
+    backgroundColor: 'rgba(90, 207, 122, 0.1)',
+    borderColor: 'rgba(90, 207, 122, 0.25)',
+  },
+  pillOffline: {
+    backgroundColor: 'rgba(229, 77, 77, 0.1)',
+    borderColor: 'rgba(229, 77, 77, 0.25)',
+  },
+  pillDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  pillText: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+  },
+
   cardFooter: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -541,5 +935,11 @@ const styles = StyleSheet.create({
     color: colors.textPrimary,
     fontWeight: '600',
     fontSize: 13,
+    marginTop: 2,
+  },
+  lastSeen: {
+    ...typography.label,
+    color: colors.textMuted,
+    fontSize: 11,
   },
 });


### PR DESCRIPTION
Logika stranice senzora prebacena s mock podataka na bazu podataka, dodan api endpoint, kao i na web verziji.
- SensorsScreen prebacen s mock podataka na pravi /api/sensors endpoint
- Online/offline status iz last_seen (< 5 min = online)
- Zadnje očitanje formatirano iz last_event_payload (temp, vrata, dim, pokret, baterija)
- Filter veza (online/offline) uz postojeće filtere tipa i statusa
- CRUD operacije: dodavanje (s prikazom API kljuca), uredivanje, brisanje senzora s potvrdom
- Novi SensorDetailScreen sa popisom zadnjih 50 dogadaja
- SensorFormModal i ApiKeyModal komponente
- Dashboard koristi prave brojeve aktivnih senzora i prikazuje online/offline status umjesto mock liste
- Pull-to-refresh na obje stranice